### PR TITLE
fix: recover I2C bus before trying to read sensor ID

### DIFF
--- a/sensor/lsm303agr/lsm303agr.c
+++ b/sensor/lsm303agr/lsm303agr.c
@@ -558,6 +558,9 @@ static int lsm303agr_init(const struct device *dev)
     if (!device_is_ready(cfg->i2c))
         return -ENODEV;
 
+    /* Recover I2C bus */
+    status = i2c_recover_bus(cfg->i2c_acc.bus);
+
     status = lsm303agr_xl_device_id_get(&cfg->i2c_acc, &id);
     if (status < 0)
         return status;


### PR DESCRIPTION
The firs I2C read during LSM303AGR driver initialization would fail often.
The i2c_recover_bus call seems to fix the problem